### PR TITLE
Fix Lab5_power-management.md (WiFi.begin() before getting MAC)

### DIFF
--- a/Lab5_power-management/Lab5_power-management.md
+++ b/Lab5_power-management/Lab5_power-management.md
@@ -23,6 +23,7 @@ void setup(){
   Serial.begin(115200);
   while(!Serial);
   delay(1000);
+  WiFi.begin();
   Serial.println();
   Serial.print("ESP Board MAC Address:  ");
   Serial.println(WiFi.macAddress());


### PR DESCRIPTION
This PR resolves an issue in Lab5_power-management.md where `WiFi.begin(ssid, password)` is not called before `WiFi.macAddress()`.